### PR TITLE
Add configurable output directory for nessai

### DIFF
--- a/nessai/proposal/base.py
+++ b/nessai/proposal/base.py
@@ -5,6 +5,7 @@ Base object for all proposal classes.
 
 import datetime
 import logging
+import os
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -84,6 +85,33 @@ class Proposal(ABC):
         Resume the proposal with the model
         """
         self.model = model
+
+    def update_output_directory(self, output_directory):
+        """
+        Update the output directory for the proposal.
+        
+        This method allows changing the output directory after the proposal
+        has been initialized. This is useful when the sampler needs to 
+        change its output location.
+        
+        Parameters
+        ----------
+        output_directory : str
+            The new output directory path. If None, uses the current 
+            working directory.
+        """
+        if output_directory is None:
+            output_directory = os.getcwd()
+        
+        # Store the output directory if the proposal uses it
+        if hasattr(self, 'output'):
+            self.output = output_directory
+            logger.debug(f"Updated output directory to: {output_directory}")
+        else:
+            # For proposals that don't have an output attribute by default,
+            # we add it so subclasses can use it if needed
+            self.output = output_directory
+            logger.debug(f"Set output directory to: {output_directory}")
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tests/test_proposal/test_base_proposal.py
+++ b/tests/test_proposal/test_base_proposal.py
@@ -4,8 +4,9 @@ Test the base proposal class.
 """
 
 import logging
+import os
 import pickle
-from unittest.mock import MagicMock, Mock, create_autospec
+from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import numpy as np
 import pytest
@@ -96,6 +97,39 @@ def test_resume(proposal):
     assert proposal.model is model
 
 
+def test_update_output_directory(proposal):
+    """Test the update_output_directory method with a specific directory."""
+    test_dir = "/test/output/dir"
+    Proposal.update_output_directory(proposal, test_dir)
+    assert proposal.output == test_dir
+
+
+def test_update_output_directory_none(proposal):
+    """Test the update_output_directory method with None (should use cwd)."""
+    with patch('os.getcwd', return_value='/current/working/dir'):
+        Proposal.update_output_directory(proposal, None)
+        assert proposal.output == '/current/working/dir'
+
+
+def test_update_output_directory_existing_attribute(proposal):
+    """Test updating when output attribute already exists."""
+    proposal.output = "/old/dir"
+    test_dir = "/new/dir"
+    Proposal.update_output_directory(proposal, test_dir)
+    assert proposal.output == test_dir
+
+
+def test_update_output_directory_no_existing_attribute(proposal):
+    """Test updating when output attribute doesn't exist."""
+    # Make sure output attribute doesn't exist
+    if hasattr(proposal, 'output'):
+        delattr(proposal, 'output')
+    
+    test_dir = "/test/dir"
+    Proposal.update_output_directory(proposal, test_dir)
+    assert proposal.output == test_dir
+
+
 def test_getstate(proposal):
     """Test the get state method called by pickle."""
     proposal.model = Mock()
@@ -110,3 +144,19 @@ def test_pickling(model):
     d = pickle.dumps(proposal)
     out = pickle.loads(d)
     assert hasattr(out, "model") is False
+
+
+@pytest.mark.integration_test
+def test_update_output_directory_integration(model, tmpdir):
+    """Test update_output_directory with a real DummyProposal instance."""
+    proposal = DummyProposal(model)
+    
+    # Test setting a specific directory
+    test_dir = str(tmpdir.mkdir("test_output"))
+    proposal.update_output_directory(test_dir)
+    assert proposal.output == test_dir
+    
+    # Test with None (should use cwd)
+    with patch('os.getcwd', return_value='/mock/cwd'):
+        proposal.update_output_directory(None)
+        assert proposal.output == '/mock/cwd'


### PR DESCRIPTION
Adds `update_output_directory` to `Proposal` to allow dynamic modification of the output path after initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-36e1ccc5-c833-4fee-9f05-b1b5dde8e8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36e1ccc5-c833-4fee-9f05-b1b5dde8e8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

