### PR TITLE
Add configurable output directory for nessai

### DIFF
--- a/nessai/proposal/base.py
+++ b/nessai/proposal/base.py
@@ -5,6 +5,7 @@ Base object for all proposal classes.
 
 import datetime
 import logging
+import os
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -33,6 +34,7 @@ class Proposal(ABC):
         self.samples = []
         self.indices = []
         self._checked_population = True
+        self.output = None
 
     @property
     def initialised(self):
@@ -84,6 +86,26 @@ class Proposal(ABC):
         Resume the proposal with the model
         """
         self.model = model
+
+    def update_output_directory(self, output):
+        """
+        Update the output directory for saving results.
+
+        Parameters
+        ----------
+        output : str
+            Path to the new output directory. If None, uses the current 
+            working directory. The directory will be created if it doesn't exist.
+        """
+        if output is None:
+            output = os.getcwd()
+        
+        if not os.path.exists(output):
+            os.makedirs(output, exist_ok=True)
+            logger.debug(f"Created output directory: {output}")
+        
+        self.output = output
+        logger.debug(f"Updated output directory to: {output}")
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tests/test_proposal/test_base_proposal.py
+++ b/tests/test_proposal/test_base_proposal.py
@@ -4,8 +4,10 @@ Test the base proposal class.
 """
 
 import logging
+import os
 import pickle
-from unittest.mock import MagicMock, Mock, create_autospec
+import tempfile
+from unittest.mock import MagicMock, Mock, create_autospec, patch
 
 import numpy as np
 import pytest
@@ -32,6 +34,7 @@ def test_init(proposal):
     assert proposal.training_count == 0
     assert proposal._checked_population is True
     assert proposal.population_time.total_seconds() == 0
+    assert proposal.output is None
 
 
 def test_init_with_draw():
@@ -96,6 +99,44 @@ def test_resume(proposal):
     assert proposal.model is model
 
 
+def test_update_output_directory_with_existing_dir(proposal):
+    """Test updating output directory with an existing directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Proposal.update_output_directory(proposal, tmpdir)
+        assert proposal.output == tmpdir
+
+
+def test_update_output_directory_creates_dir(proposal):
+    """Test that update_output_directory creates a directory if it doesn't exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        new_dir = os.path.join(tmpdir, "new_output")
+        assert not os.path.exists(new_dir)
+        
+        Proposal.update_output_directory(proposal, new_dir)
+        
+        assert os.path.exists(new_dir)
+        assert proposal.output == new_dir
+
+
+def test_update_output_directory_with_none(proposal):
+    """Test that passing None uses the current working directory."""
+    cwd = os.getcwd()
+    Proposal.update_output_directory(proposal, None)
+    assert proposal.output == cwd
+
+
+def test_update_output_directory_logging(proposal, caplog):
+    """Test that update_output_directory logs debug messages."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        new_dir = os.path.join(tmpdir, "test_output")
+        
+        with caplog.at_level(logging.DEBUG):
+            Proposal.update_output_directory(proposal, new_dir)
+        
+        assert f"Created output directory: {new_dir}" in caplog.text
+        assert f"Updated output directory to: {new_dir}" in caplog.text
+
+
 def test_getstate(proposal):
     """Test the get state method called by pickle."""
     proposal.model = Mock()
@@ -110,3 +151,31 @@ def test_pickling(model):
     d = pickle.dumps(proposal)
     out = pickle.loads(d)
     assert hasattr(out, "model") is False
+
+
+@pytest.mark.integration_test
+def test_update_output_directory_integration(model):
+    """Integration test for update_output_directory method."""
+    proposal = DummyProposal(model)
+    
+    # Initial output should be None
+    assert proposal.output is None
+    
+    # Test with a temporary directory
+    with tempfile.TemporaryDirectory() as tmpdir:
+        new_dir = os.path.join(tmpdir, "test_output")
+        proposal.update_output_directory(new_dir)
+        
+        assert proposal.output == new_dir
+        assert os.path.exists(new_dir)
+        
+        # Test updating to another directory
+        another_dir = os.path.join(tmpdir, "another_output")
+        proposal.update_output_directory(another_dir)
+        
+        assert proposal.output == another_dir
+        assert os.path.exists(another_dir)
+    
+    # Test with None (should use cwd)
+    proposal.update_output_directory(None)
+    assert proposal.output == os.getcwd()


### PR DESCRIPTION
Add `update_output_directory` method to `Proposal` to allow dynamic modification of the output path.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dce5f23-99f6-408b-9e2b-1bc07d48cfae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1dce5f23-99f6-408b-9e2b-1bc07d48cfae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

